### PR TITLE
fix: solve padding on tablet

### DIFF
--- a/libs/blocks/src/lib/hero/content-bottom/index.tsx
+++ b/libs/blocks/src/lib/hero/content-bottom/index.tsx
@@ -20,7 +20,7 @@ const ContentBottom = ({
         className,
       )}
     >
-      <FluidContainer className="flex flex-col gap-gap-3xl">
+      <FluidContainer className="flex flex-col gap-gap-3xl md:px-general-lg lg:px-general-none">
         <Heading.H1 className="text-center">{title}</Heading.H1>
         {children}
       </FluidContainer>


### PR DESCRIPTION
padding left right on tablet is 24px and 16px on mobile
![image](https://github.com/deriv-com/deriv-com-v2/assets/142988136/52fbc63c-6702-4db1-95e4-407a54953d7a)
![image](https://github.com/deriv-com/deriv-com-v2/assets/142988136/bb09f182-13a2-4e9f-bec5-99f6f647cdaa)