### PR TITLE
Jia/fix description font color and mobile size padding

### DIFF
--- a/libs/blocks/src/lib/hero/content-limit/index.tsx
+++ b/libs/blocks/src/lib/hero/content-limit/index.tsx
@@ -41,7 +41,7 @@ const ContentLimit: React.FC<ContentLimitProps> = ({
         )}
       >
         <div
-          className={clsx('flex flex-1 flex-col gap-gap-3xl pr-general-2xl')}
+          className={clsx('flex flex-1 flex-col gap-gap-3xl lg:pr-general-2xl')}
         >
           <div className="flex flex-col gap-gap-2xl">
             <Heading.H1>{title}</Heading.H1>

--- a/libs/blocks/src/lib/stat/numbers-with-title/index.tsx
+++ b/libs/blocks/src/lib/stat/numbers-with-title/index.tsx
@@ -16,11 +16,9 @@ export const NumbersWithTitle: React.FC<NumbersWithTitleProps> = ({
     <Section className="bg-solid-slate-75 py-general-4xl">
       <FluidContainer className="flex flex-col gap-gap-3xl bg-solid-slate-75">
         <div className="flex flex-col items-center gap-gap-lg text-center lg:gap-gap-xl">
-          {title && (
-            <Heading.H2 className="text-solid-slate-1400">{title}</Heading.H2>
-          )}
+          {title && <Heading.H2>{title}</Heading.H2>}
           {description && (
-            <Text size="xl" className="text-solid-slate-1400">
+            <Text size="xl" className="text-typography-default">
               {description}
             </Text>
           )}


### PR DESCRIPTION
Fix padding-right exists on mobile and tablet size
![image](https://github.com/deriv-com/deriv-com-v2/assets/142988136/258c4a7c-abfd-416d-ae07-7446295c1681)
Change the description color to follow Figma design
![image](https://github.com/deriv-com/deriv-com-v2/assets/142988136/6bb61d7d-3ccc-4235-a0c4-9568252269aa)