### PR TITLE
Jia/fix card description font color to grey

### DIFF
--- a/libs/components/src/lib/card/base/index.tsx
+++ b/libs/components/src/lib/card/base/index.tsx
@@ -103,7 +103,12 @@ export const BaseCard: React.FC<BaseCardProps> = ({
           >
             {header && <HeadingComponent>{header}</HeadingComponent>}
             {description && (
-              <Text size={textSizeVariant[size]}>{description}</Text>
+              <Text
+                size={textSizeVariant[size]}
+                className="text-typography-default"
+              >
+                {description}
+              </Text>
             )}
           </div>
         )}


### PR DESCRIPTION
fix all the card descriptions should be in grey color
![image](https://github.com/deriv-com/deriv-com-v2/assets/142988136/04e2f45e-ec02-4360-b80e-b8e0fa1d8f26)