### PR TITLE
Jia/Fix-IOS-name-and-app-rendering-section

### DIFF
--- a/libs/templates/src/lib/trade/app-download/data.tsx
+++ b/libs/templates/src/lib/trade/app-download/data.tsx
@@ -45,7 +45,7 @@ export const data = {
     },
     {
       icon: <StandaloneIosIcon />,
-      name: 'IOS',
+      name: 'iOS',
     },
     {
       icon: <StandaloneLinuxIcon />,

--- a/libs/templates/src/lib/trade/app-download/index.tsx
+++ b/libs/templates/src/lib/trade/app-download/index.tsx
@@ -1,5 +1,10 @@
 import React, { HTMLAttributes } from 'react';
-import { BodyTypographyProps, Heading, Text } from '@deriv/quill-design';
+import {
+  BodyTypographyProps,
+  FluidContainer,
+  Heading,
+  Text,
+} from '@deriv/quill-design';
 import { Card } from '@deriv-com/components';
 import { data } from './data';
 import clsx from 'clsx';
@@ -24,46 +29,48 @@ const AppDownload = () => {
   };
 
   return (
-    <Card.ContentRight
-      color="gray"
-      align="start"
-      size="lg"
-      content={content}
-      contentClassName="w-full flex justify-center"
-      className="lg:gap-gap-lg"
-    >
-      <CustomDiv className="flex-col gap-gap-2xl">
-        <CustomDiv className="flex-col gap-gap-xl">
-          <Heading.H2>{heading}</Heading.H2>
-          <CustomText className="text-body-lg leading-body-lg">
-            {description}
-          </CustomText>
-        </CustomDiv>
+    <FluidContainer>
+      <Card.ContentRight
+        color="gray"
+        align="start"
+        size="lg"
+        content={content}
+        contentClassName="w-full flex justify-center"
+        className="lg:gap-gap-lg"
+      >
+        <CustomDiv className="flex-col gap-gap-2xl">
+          <CustomDiv className="flex-col gap-gap-xl">
+            <Heading.H2>{heading}</Heading.H2>
+            <CustomText className="text-body-lg leading-body-lg">
+              {description}
+            </CustomText>
+          </CustomDiv>
 
-        <CustomDiv className="w-full flex-col gap-gap-xl md:flex-row lg:flex-col">
-          <CustomDiv className="w-full items-start gap-gap-lg">
-            {cta.qr}
-            <div className="grid w-[134px] gap-gap-md lg:w-full">
-              <CustomText>{cta.description}</CustomText>
-              <CustomText bold className="text-body-lg">
-                {cta.devices}
-              </CustomText>
-            </div>
-          </CustomDiv>
-          <CustomDiv className="w-full flex-wrap gap-gap-lg">
-            {platforms.map((platform) => (
-              <CustomDiv
-                className="items-center gap-gap-md"
-                key={platform.name}
-              >
-                {platform.icon}
-                <Text>{platform.name}</Text>
-              </CustomDiv>
-            ))}
+          <CustomDiv className="w-full flex-col gap-gap-xl md:flex-row lg:flex-col">
+            <CustomDiv className="w-full items-start gap-gap-lg">
+              {cta.qr}
+              <div className="grid w-[134px] gap-gap-md lg:w-full">
+                <CustomText>{cta.description}</CustomText>
+                <CustomText bold className="text-body-lg">
+                  {cta.devices}
+                </CustomText>
+              </div>
+            </CustomDiv>
+            <CustomDiv className="w-full flex-wrap gap-gap-lg">
+              {platforms.map((platform) => (
+                <CustomDiv
+                  className="items-center gap-gap-md"
+                  key={platform.name}
+                >
+                  {platform.icon}
+                  <Text>{platform.name}</Text>
+                </CustomDiv>
+              ))}
+            </CustomDiv>
           </CustomDiv>
         </CustomDiv>
-      </CustomDiv>
-    </Card.ContentRight>
+      </Card.ContentRight>
+    </FluidContainer>
   );
 };
 

--- a/libs/templates/src/lib/trade/app-download/index.tsx
+++ b/libs/templates/src/lib/trade/app-download/index.tsx
@@ -22,7 +22,7 @@ const AppDownload = () => {
   };
 
   return (
-    <FluidContainer>
+    <FluidContainer className="py-general-4xl">
       <Card.ContentRight
         color="gray"
         align="start"

--- a/libs/templates/src/lib/trade/app-download/index.tsx
+++ b/libs/templates/src/lib/trade/app-download/index.tsx
@@ -31,16 +31,16 @@ const AppDownload = () => {
         contentClassName="w-full flex justify-center"
         className="lg:gap-gap-lg"
       >
-        <div className="flex  flex-col gap-gap-2xl">
-          <div className="flex  flex-col gap-gap-xl">
+        <div className="flex flex-col gap-gap-2xl">
+          <div className="flex flex-col gap-gap-xl">
             <Heading.H2>{heading}</Heading.H2>
             <CustomText className="text-body-lg leading-body-lg">
               {description}
             </CustomText>
           </div>
 
-          <div className="flex  w-full flex-col gap-gap-xl md:flex-row lg:flex-col">
-            <div className="flex  w-full items-start gap-gap-lg">
+          <div className="flex w-full flex-col gap-gap-xl md:flex-row lg:flex-col">
+            <div className="flex w-full items-start gap-gap-lg">
               {cta.qr}
               <div className="grid w-[134px] gap-gap-md lg:w-full">
                 <CustomText>{cta.description}</CustomText>
@@ -49,7 +49,7 @@ const AppDownload = () => {
                 </CustomText>
               </div>
             </div>
-            <div className="flex  w-full flex-wrap gap-gap-lg">
+            <div className="flex w-full flex-wrap gap-gap-lg">
               {platforms.map((platform) => (
                 <div
                   className="flex items-center gap-gap-md"

--- a/libs/templates/src/lib/trade/app-download/index.tsx
+++ b/libs/templates/src/lib/trade/app-download/index.tsx
@@ -21,13 +21,6 @@ const AppDownload = () => {
     );
   };
 
-  const CustomDiv: React.FC<HTMLAttributes<HTMLParagraphElement>> = ({
-    className,
-    ...props
-  }) => {
-    return <div className={clsx('flex', className)} {...props} />;
-  };
-
   return (
     <FluidContainer>
       <Card.ContentRight
@@ -38,16 +31,16 @@ const AppDownload = () => {
         contentClassName="w-full flex justify-center"
         className="lg:gap-gap-lg"
       >
-        <CustomDiv className="flex-col gap-gap-2xl">
-          <CustomDiv className="flex-col gap-gap-xl">
+        <div className="flex  flex-col gap-gap-2xl">
+          <div className="flex  flex-col gap-gap-xl">
             <Heading.H2>{heading}</Heading.H2>
             <CustomText className="text-body-lg leading-body-lg">
               {description}
             </CustomText>
-          </CustomDiv>
+          </div>
 
-          <CustomDiv className="w-full flex-col gap-gap-xl md:flex-row lg:flex-col">
-            <CustomDiv className="w-full items-start gap-gap-lg">
+          <div className="flex  w-full flex-col gap-gap-xl md:flex-row lg:flex-col">
+            <div className="flex  w-full items-start gap-gap-lg">
               {cta.qr}
               <div className="grid w-[134px] gap-gap-md lg:w-full">
                 <CustomText>{cta.description}</CustomText>
@@ -55,20 +48,20 @@ const AppDownload = () => {
                   {cta.devices}
                 </CustomText>
               </div>
-            </CustomDiv>
-            <CustomDiv className="w-full flex-wrap gap-gap-lg">
+            </div>
+            <div className="flex  w-full flex-wrap gap-gap-lg">
               {platforms.map((platform) => (
-                <CustomDiv
-                  className="items-center gap-gap-md"
+                <div
+                  className="flex items-center gap-gap-md"
                   key={platform.name}
                 >
                   {platform.icon}
                   <Text>{platform.name}</Text>
-                </CustomDiv>
+                </div>
               ))}
-            </CustomDiv>
-          </CustomDiv>
-        </CustomDiv>
+            </div>
+          </div>
+        </div>
       </Card.ContentRight>
     </FluidContainer>
   );

--- a/libs/templates/src/lib/trade/index.tsx
+++ b/libs/templates/src/lib/trade/index.tsx
@@ -2,6 +2,7 @@ import { Hero } from '@deriv-com/blocks';
 import { PageLayout } from '@deriv-com/components';
 import { Text } from '@deriv/quill-design';
 import TradingSpecTable from './table/trading-spec-table';
+import AppDownload from './app-download';
 
 export function TradeTemplate() {
   return (
@@ -13,6 +14,7 @@ export function TradeTemplate() {
         </Text>
       </Hero.ContentLess>
       <TradingSpecTable />
+      <AppDownload />
     </PageLayout>
   );
 }


### PR DESCRIPTION
fix ios name form IOS to iOS and app rendering section missing in trade page
![image](https://github.com/deriv-com/deriv-com-v2/assets/142988136/25eb7cfd-3ad7-49c9-a89c-fea716dff47e)