### PR TITLE
Prince/fix: incorrect card variant title

### DIFF
--- a/libs/components/src/lib/card/content-right/content-right.stories.tsx
+++ b/libs/components/src/lib/card/content-right/content-right.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    header: 'Content Left Card',
+    header: 'Content Right Card',
     description: 'This is a description',
     align: 'center',
     color: 'light',


### PR DESCRIPTION
## Changes
- Updated `ContentRight` card variant title on storybook 