### PR TITLE
Jia/fix: padding and gap for mobile and tablet screen

### DIFF
--- a/libs/blocks/src/lib/hero/content-limitless/index.tsx
+++ b/libs/blocks/src/lib/hero/content-limitless/index.tsx
@@ -18,8 +18,9 @@ const ContentLimitless: React.FC<ContentLimitlessProps> = ({
 }) => {
   return (
     <Section
+      // todo: we need 72px gap for desktop 48px gap for mobile and tablet
       className={clsx(
-        'relative mx-auto flex max-w-[2048px] flex-col items-center justify-center gap-gap-3xl pt-general-2xl lg:block lg:min-h-[680px] xl:min-h-screen',
+        'relative mx-auto flex max-w-[2048px] flex-col items-center justify-center gap-general-4xl pt-general-4xl lg:block lg:min-h-[680px] lg:pt-general-2xl xl:min-h-screen',
         className,
       )}
     >


### PR DESCRIPTION
change padding and gap from 32px to 48px
![image](https://github.com/deriv-com/deriv-com-v2/assets/142988136/e7bb9368-8263-46c5-a5a1-6eb2b8f99302)