### PR TITLE
Jia/fix: white space under image on safari

### DIFF
--- a/libs/templates/src/lib/trade/app-download/index.tsx
+++ b/libs/templates/src/lib/trade/app-download/index.tsx
@@ -29,7 +29,7 @@ const AppDownload = () => {
         size="lg"
         content={content}
         contentClassName="w-full flex justify-center"
-        className="lg:gap-gap-lg"
+        className="items-center lg:gap-gap-lg xl:items-end"
       >
         <div className="flex flex-col gap-gap-2xl">
           <div className="flex flex-col gap-gap-xl">


### PR DESCRIPTION
Fix white space only shown on safari.
![Screenshot 2023-11-07 at 6 21 01 PM](https://github.com/deriv-com/deriv-com-v2/assets/142988136/ed3effa3-f35f-47b2-ab70-ed2bba947c26)
![Screenshot 2023-11-07 at 6 22 46 PM](https://github.com/deriv-com/deriv-com-v2/assets/142988136/caac9c4a-02fd-40bd-8a0b-9975718ca668)
