### PR TITLE
Jia/fix: remove rewind and content not align compare to Figma

### DIFF
--- a/libs/components/src/lib/card-slider/index.tsx
+++ b/libs/components/src/lib/card-slider/index.tsx
@@ -49,7 +49,6 @@ export const CardSlider = <T extends CardVariantType>({
         slidesPerView={slidesPerView}
         spaceBetween={spaceBetween}
         breakpoints={breakpoints}
-        rewind
       >
         {cards.map((card, index) => (
           <SwiperSlide className={clsx(slideClasses)} key={index}>

--- a/libs/templates/src/lib/who-we-are/sections/our-values/index.tsx
+++ b/libs/templates/src/lib/who-we-are/sections/our-values/index.tsx
@@ -58,7 +58,7 @@ export const WhoWeAreValues = () => {
       cardSliderProps={{
         cards: ourValuesCards,
         variant: 'ContentBottom',
-        slideClasses: 'max-w-[242px] md:max-w-[296px]',
+        slideClasses: 'max-w-[286px] md:max-w-[296px]',
         className: 'w-full',
       }}
     />


### PR DESCRIPTION
- Fix card slider section unable to view the last card because of rewind loop back to the first card.
- Fix card width is not same as Figma
![Screenshot 2023-11-14 at 7 00 05 PM](https://github.com/deriv-com/deriv-com-v2/assets/142988136/0d2980c5-7a5d-40f3-916e-fc150d4aaaa2)
