### PR TITLE
Jia/fix: home page cta gap between button and title

### DIFF
--- a/libs/components/src/lib/card/base/index.tsx
+++ b/libs/components/src/lib/card/base/index.tsx
@@ -33,7 +33,7 @@ const sizeVariantComponents = {
 const sizeVariantContainerGap = {
   sm: 'gap-gap-lg p-general-xl',
   md: 'gap-gap-xl p-general-2xl',
-  lg: 'gap-gap-xl p-general-3xl',
+  lg: 'gap-gap-2xl p-general-3xl',
 };
 
 const sizeVariantTextGap = {


### PR DESCRIPTION
- Fix the gap on cta home page between the title and button for desktop view should be 32px.
![image](https://github.com/deriv-com/deriv-com-v2/assets/142988136/35caba49-9913-4207-8e51-0641a0ad693a)