### PR TITLE
Meenu/fix: updated font size for desctiption in content limit

### DIFF
--- a/libs/blocks/src/lib/hero/content-limit/index.tsx
+++ b/libs/blocks/src/lib/hero/content-limit/index.tsx
@@ -40,11 +40,7 @@ const ContentLimit: React.FC<ContentLimitProps> = ({
         >
           <div className="flex flex-col gap-gap-2xl">
             <Heading.H1>{title}</Heading.H1>
-            {description && (
-              <Text size="xl" className="text-typography-default">
-                {description}
-              </Text>
-            )}
+            {description && <Text>{description}</Text>}
           </div>
 
           <div className="w-full">{children}</div>


### PR DESCRIPTION
- Updated font size for description to `16px` as per [figma](https://www.figma.com/file/LWWOYmFDTHLEkdsYTgI2kZ/UI-Library-%5BNew%5D?node-id=3308%3A9715&mode=dev)