### PR TITLE
Hasan/chore: fixed card container columns for less than two items

### DIFF
--- a/libs/components/src/lib/cards-container/cards-container.classname.ts
+++ b/libs/components/src/lib/cards-container/cards-container.classname.ts
@@ -1,5 +1,29 @@
 import { cva } from 'class-variance-authority';
 
+/**
+ * * Important: The gap is currently set at 16px. If additional gap variants are introduced, make sure to update this value accordingly.
+ */
+export const cardClass = cva('gap-gap-lg pr-general-md', {
+  variants: {
+    cols: {
+      two: '',
+      three: 'lg:basis-[calc((100%-16px*2)/3)]',
+      four: 'lg:basis-[calc((100%-16px*3)/4)]',
+      five: 'lg:basis-[calc((100%-16px*4)/5)]',
+      infinite: 'flex',
+    },
+  },
+  compoundVariants: [
+    {
+      cols: ['two', 'three', 'four', 'five'],
+      className: 'basis-full sm:basis-[calc((100%-16px)/2)]',
+    },
+  ],
+  defaultVariants: {
+    cols: 'two',
+  },
+});
+
 export const colsClass = cva('flex flex-wrap gap-gap-lg', {
   variants: {
     dense: {
@@ -7,14 +31,27 @@ export const colsClass = cva('flex flex-wrap gap-gap-lg', {
       false: '',
     },
     justify: {
-      center: 'lg:justify-center',
-      start: 'justify-start',
+      center: '',
+      start: '',
+    },
+    itemLessThanTwo: {
+      true: 'justify-center',
     },
   },
   compoundVariants: [
     {
       dense: [true, false],
       className: 'w-full',
+    },
+    {
+      justify: 'start',
+      itemLessThanTwo: false,
+      className: 'justify-start',
+    },
+    {
+      justify: 'center',
+      itemLessThanTwo: false,
+      className: 'lg:justify-center',
     },
   ],
   defaultVariants: {

--- a/libs/components/src/lib/cards-container/cards-container.classname.ts
+++ b/libs/components/src/lib/cards-container/cards-container.classname.ts
@@ -10,7 +10,6 @@ export const cardClass = cva('gap-gap-lg pr-general-md', {
       three: 'lg:basis-[calc((100%-16px*2)/3)]',
       four: 'lg:basis-[calc((100%-16px*3)/4)]',
       five: 'lg:basis-[calc((100%-16px*4)/5)]',
-      infinite: 'flex',
     },
   },
   compoundVariants: [

--- a/libs/components/src/lib/cards-container/index.tsx
+++ b/libs/components/src/lib/cards-container/index.tsx
@@ -1,6 +1,5 @@
 import { qtJoin, qtMerge } from '@deriv/quill-design';
 import Card, { CardVariants } from '../card';
-import { cva } from 'class-variance-authority';
 import {
   cardClass,
   cardContainer,

--- a/libs/components/src/lib/cards-container/index.tsx
+++ b/libs/components/src/lib/cards-container/index.tsx
@@ -1,4 +1,4 @@
-import { qtMerge } from '@deriv/quill-design';
+import { qtJoin, qtMerge } from '@deriv/quill-design';
 import Card, { CardVariants } from '../card';
 import { cva } from 'class-variance-authority';
 import {
@@ -51,7 +51,7 @@ export const CardsContainer = <T extends CardVariantType>({
         Array.from({ length: 3 }, (_, index) => (
           <div
             key={index}
-            className={sliderClass}
+            className={qtJoin('flex gap-gap-lg pr-general-md', sliderClass)}
             data-testid="infinite-carousel"
           >
             {cards.map((card) => (

--- a/libs/components/src/lib/cards-container/index.tsx
+++ b/libs/components/src/lib/cards-container/index.tsx
@@ -1,7 +1,11 @@
 import { qtMerge } from '@deriv/quill-design';
 import Card, { CardVariants } from '../card';
 import { cva } from 'class-variance-authority';
-import { cardContainer, colsClass } from './cards-container.classname';
+import {
+  cardClass,
+  cardContainer,
+  colsClass,
+} from './cards-container.classname';
 
 export type CardVariantType = keyof CardVariants;
 
@@ -21,10 +25,6 @@ export interface CardsContainerProps<T extends CardVariantType> {
   sliderClass?: string;
 }
 
-/**
- * * Important: The gap is currently set at 16px. If additional gap variants are introduced, make sure to update this value accordingly.
- */
-
 const columns = {
   two: 2,
   three: 3,
@@ -42,31 +42,6 @@ export const CardsContainer = <T extends CardVariantType>({
 }: CardsContainerProps<T>) => {
   const CardComponent = Card[variant];
 
-  const div = cva('gap-gap-lg pr-general-md', {
-    variants: {
-      cols: {
-        two: '',
-        three: 'lg:basis-[calc((100%-16px*2)/3)]',
-        four: 'lg:basis-[calc((100%-16px*3)/4)]',
-        five: 'lg:basis-[calc((100%-16px*4)/5)]',
-        infinite: 'flex',
-      },
-    },
-    compoundVariants: [
-      {
-        cols: ['two', 'three', 'four', 'five'],
-        className: 'basis-full sm:basis-[calc((100%-16px)/2)]',
-      },
-      {
-        cols: ['infinite'],
-        className: sliderClass,
-      },
-    ],
-    defaultVariants: {
-      cols: 'two',
-    },
-  });
-
   return (
     <div
       className={qtMerge(cardContainer({ cols: cols }), className)}
@@ -76,7 +51,7 @@ export const CardsContainer = <T extends CardVariantType>({
         Array.from({ length: 3 }, (_, index) => (
           <div
             key={index}
-            className={div({ cols: cols })}
+            className={sliderClass}
             data-testid="infinite-carousel"
           >
             {cards.map((card) => (
@@ -91,13 +66,14 @@ export const CardsContainer = <T extends CardVariantType>({
           className={colsClass({
             dense: dense,
             justify: cards.length < columns[cols] ? 'center' : 'start',
+            itemLessThanTwo: cards.length < 2,
           })}
         >
           {cards.map((card) => (
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
             <CardComponent
-              className={div({ cols: cols })}
+              className={cardClass({ cols: cols })}
               key={card.id}
               {...card}
             />


### PR DESCRIPTION
Given that we display a minimum of two cards, the center position will be guaranteed if the number of cards is less than two.