### PR TITLE
Meenu/fix: pass children as optional param in hero content less block

### DIFF
--- a/libs/blocks/src/lib/hero/content-less/index.tsx
+++ b/libs/blocks/src/lib/hero/content-less/index.tsx
@@ -26,7 +26,7 @@ const ContentLess = ({
           )}
         </div>
 
-        {children}
+        {children && children}
       </FluidContainer>
     </Section>
   );


### PR DESCRIPTION
- Deriv com implementation requires Hero ContentLess block which has only title and description.  Using Hero.ContentLess throws error as we are passing children. 
- Hence passing children as optional param. 