### PR TITLE
Meenu/fix: updated ts for strings with reactnode and ucards without padding

### DIFF
--- a/libs/blocks/src/lib/features/card-feature/card-feature.stories.tsx
+++ b/libs/blocks/src/lib/features/card-feature/card-feature.stories.tsx
@@ -18,6 +18,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
+    hasPadding: true,
     description:
       'Description goes here description goes here description goes here description goes here',
     cta: (
@@ -27,6 +28,71 @@ export const Default: Story = {
     ),
     title: '20+ years of proven excellence',
     cols: 'four',
+    cards: [
+      {
+        id: 1,
+        header: 'Protected and secure',
+        description:
+          'Your data is safe, and your funds are in segregated bank accounts per regulatory standards.',
+        icon: <IllustrativeProtectedAndSecureIcon />,
+        color: 'gray',
+        align: 'start',
+        size: 'sm',
+        link: {
+          content: 'Learn more',
+          href: '/',
+        },
+      },
+      {
+        id: 2,
+        header: '24/7 support',
+        description:
+          'Reach our professional, multilingual team anytime via live chat.',
+        icon: <IllustrativeSupport247Icon />,
+        color: 'gray',
+        align: 'start',
+        size: 'sm',
+        link: {
+          content: 'Learn more',
+          href: '/',
+        },
+      },
+      {
+        id: 3,
+        header: 'Regulated',
+        description:
+          'We are licensed and overseen by leading global financial authorities.',
+        icon: <IllustrativeLicensedAndRegulatedIcon />,
+        color: 'gray',
+        align: 'start',
+        size: 'sm',
+        link: {
+          content: 'Learn more',
+          href: '/',
+        },
+      },
+      {
+        id: 4,
+        header: 'Reliable',
+        icon: <IllustrativeSpreadsIcon />,
+        description:
+          'With 99.97% uptime, we process 5.6 million trades daily, offering seamless and uninterrupted trading.',
+        color: 'gray',
+        align: 'start',
+        size: 'sm',
+        link: {
+          content: 'Learn more',
+          href: '/',
+        },
+      },
+    ],
+  },
+};
+
+export const WithoutPadding: Story = {
+  args: {
+    hasPadding: false,
+    cols: 'two',
     cards: [
       {
         id: 1,

--- a/libs/blocks/src/lib/features/card-feature/index.tsx
+++ b/libs/blocks/src/lib/features/card-feature/index.tsx
@@ -21,12 +21,14 @@ export interface FeatureCardProps {
   cards?: CardContent[];
   cols?: 'two' | 'three' | 'four';
   variant?: CardVariantType;
+  hasPadding?: boolean;
 }
 
 const Card = ({
   title,
   description,
   cta,
+  hasPadding,
   className,
   cards = [],
   cols = 'two',
@@ -35,7 +37,7 @@ const Card = ({
   return (
     <Section
       className={clsx(
-        'py-general-4xl',
+        hasPadding ? 'py-general-4xl' : 'py-general-xl',
         'bg-background-primary-container',
         className,
       )}

--- a/libs/blocks/src/lib/hero/content-less/index.tsx
+++ b/libs/blocks/src/lib/hero/content-less/index.tsx
@@ -2,10 +2,10 @@ import { FluidContainer, Heading, Section, Text } from '@deriv/quill-design';
 import clsx from 'clsx';
 
 export interface ContentLessProps {
-  title: string;
-  description?: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
   className?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 const ContentLess = ({

--- a/libs/blocks/src/lib/hero/content-limit/index.tsx
+++ b/libs/blocks/src/lib/hero/content-limit/index.tsx
@@ -10,8 +10,8 @@ import React from 'react';
 
 export interface ContentLimitProps {
   className?: string;
-  title?: string;
-  description?: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
   content?: () => React.ReactNode;
   children?: React.ReactNode;
 }

--- a/libs/blocks/src/lib/hero/content-limitless/index.tsx
+++ b/libs/blocks/src/lib/hero/content-limitless/index.tsx
@@ -3,8 +3,8 @@ import { ReactNode } from 'react';
 import styles from './styles.module.scss';
 import clsx from 'clsx';
 export interface ContentLimitlessProps {
-  title?: string;
-  description?: string;
+  title?: ReactNode;
+  description?: ReactNode;
   content?: () => ReactNode;
   children?: ReactNode;
   className?: string;

--- a/libs/blocks/src/lib/hero/index.tsx
+++ b/libs/blocks/src/lib/hero/index.tsx
@@ -7,8 +7,8 @@ import { ReactNode } from 'react';
 
 export interface HeroProps {
   className?: string;
-  title?: string;
-  description?: string;
+  title?: ReactNode;
+  description?: ReactNode;
   content?: ReactNode;
   children?: ReactNode;
 }


### PR DESCRIPTION
- Type declaration for Title and strings is updated to `ReactNode` in order to use `Localize` component in deriv.com 

- There's a requirement for without padding in features card as per this [figma](https://www.figma.com/file/LWWOYmFDTHLEkdsYTgI2kZ/UI-Library-%5BNew%5D?node-id=7464%3A82886&mode=dev)