### PR TITLE
chore: make packages public

### DIFF
--- a/libs/blocks/package.json
+++ b/libs/blocks/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@deriv-com/blocks",
   "version": "0.67.0",
+  "private": false,
   "main": "./index.js",
   "exports": {
     ".": {

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@deriv-com/components",
   "version": "0.37.0",
+  "private": false,
   "main": "./index.js",
   "exports": {
     ".": {

--- a/libs/hooks/package.json
+++ b/libs/hooks/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@deriv-com/hooks",
   "version": "0.10.0",
+  "private": false,
   "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {

--- a/libs/providers/package.json
+++ b/libs/providers/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@deriv-com/providers",
   "version": "0.10.0",
+  "private": false,
   "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {


### PR DESCRIPTION
Make the packages on the GitHub registry public, so we (and members of the public community) don't need to use tokens to use them.