### PR TITLE
Ako/ publish to npm

### DIFF
--- a/.github/workflows/release-libs.yml
+++ b/.github/workflows/release-libs.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Create npmrc file
         shell: bash
-        run: echo '//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}' > .npmrc
+        run: echo '//registry.npmjs.org/:_authToken=${{ secrets.PUBLISH_NPM_TOKEN }}' > .npmrc
 
       - name: Publish Hooks
         if: steps.changed-hooks.outputs.changed == 'true'


### PR DESCRIPTION
This is to change the private github packages publish to public npm.